### PR TITLE
Fix an edge case with indented comments

### DIFF
--- a/R/format.R
+++ b/R/format.R
@@ -105,9 +105,9 @@ comment_remove_enclosing <- function(x) {
     stop("Expected a string (character vector of length 1).")
   }
   txt <- strsplit(x, "\n")[[1]]
-  comment_index <- grep(paste0('^"', comment_start), txt)
+  comment_index <- grep(paste0('^\\s*"', comment_start), txt)
   if (!length(comment_index)) return(txt)
-  txt[comment_index] <- sub(paste0('^"', comment_start), "", txt[comment_index])
+  txt[comment_index] <- sub(paste0('^(\\s*)"', comment_start), "\\1", txt[comment_index])
   txt[comment_index] <- sub(paste0(comment_end, '"$'), "", txt[comment_index])
   # e.g. `deparse("a \"string\"")` -> "\"a \\\"string\\\"\""
   txt[comment_index] <- gsub("\\\"", "\"", txt[comment_index], fixed = TRUE)

--- a/tests/testthat/test-comments.R
+++ b/tests/testthat/test-comments.R
@@ -230,5 +230,21 @@ describe("various edge cases", isolate({
     )
   )
 
+  code <- expandCode({
+    {
+      "# A comment"
+      a
+    } + b
+  })
+  expect_equal(
+    capturePrint(code),
+    c(
+      "{",
+      "  # A comment",
+      "  a",
+      "} + b"
+    )
+  )
+
   # TODO: What should happen if \n appears in a string-comment?
 }))


### PR DESCRIPTION
```r
expandCode({
  {
    "# A comment"
    a
  } + b
})
```

was returning this:

```r
{
  "######StartOfShinyMetaCommentIdentifier####### A comment######EndOfShinyMetaCommentIdentifier######"
  a
} + b
```

due to not expecting comments to have any whitespace before them.