### PR TITLE
Unsafe expansion detection

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,6 +35,7 @@ Suggests:
     dplyr,
     ggplot2,
     cranlogs,
+    xfun,
     zoo
 VignetteBuilder: knitr
 Roxygen: list(markdown = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,6 +27,7 @@ LazyData: true
 RoxygenNote: 7.1.1
 Suggests: 
     knitr,
+    stringr,
     rmarkdown,
     testthat (>= 3.0),
     shinyAce,

--- a/R/report.R
+++ b/R/report.R
@@ -61,7 +61,7 @@ buildRmdBundle <- function(report_template, output_zip_path, vars = list(),
     progress$set(value = 0.1)
     progress$set(message = "Expanding Rmd template")
 
-    rmd_source <- do.call(knit_expand_safe, c(list(report_template), vars))
+    rmd_source <- knit_expand_safe(report_template, vars = vars)
     rmd_filename <- template_rename(report_template, "Rmd")
 
     build_bundle(rmd_source, rmd_filename, output_zip_path,

--- a/R/utils.R
+++ b/R/utils.R
@@ -116,7 +116,7 @@ is_false <- function(x) {
 # Version of knit_expand that doesn't search the parent frame, and detects when
 # expansion results in unsafe Rmd input (i.e. the evaluation of {{expr}} should
 # never introduce a chunk boundary or even a new inline chunk)
-knit_expand_safe <- function(file, text = xfun::read_utf8(file), ..., delim = c("{{", "}}")) {
+knit_expand_safe <- function(file, vars = list(), text = xfun::read_utf8(file), delim = c("{{", "}}")) {
   # The approach we take here is to detect all knitr md patterns before and
   # after expansion, and fail if anything was either added or removed. We tried
   # just testing the output of each {{expansion}} for the patterns, but, that
@@ -131,7 +131,7 @@ knit_expand_safe <- function(file, text = xfun::read_utf8(file), ..., delim = c(
 
   # Create an environment that contains nothing but the variables we want to
   # make available for template expansion, plus .GlobalEnv.
-  eval_envir <- list2env(list(...), parent = .GlobalEnv)
+  eval_envir <- list2env(vars, parent = .GlobalEnv)
 
   # Use a knitr hook to ensure that only the ... arguments plus stuff in the
   # global environment are available when evaluating {{/}} expressions.

--- a/R/utils.R
+++ b/R/utils.R
@@ -112,3 +112,10 @@ mrexprSrcrefToLabel <- function(srcref, defaultLabel) {
 is_false <- function(x) {
   is.logical(x) && length(x) == 1L && !is.na(x) && !x
 }
+
+# Version of knit_expand that doesn't search the parent frame, and detects when
+# expansion results in unsafe Rmd input (i.e. the evaluation of {{expr}} should
+# never introduce a chunk boundary or even a new inline chunk)
+knit_expand_safe <- function(file, ..., delim = c("{{", "}}")) {
+  knitr::knit_expand(file, ..., delim = delim)
+}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -2,15 +2,6 @@
   # Turn on this top secret feature of Shiny! Shhhhh!
   options(shiny.allowoutputreads = TRUE)
 
-  packageStartupMessage(
-    "********************************************************************\n",
-    "* Thanks for trying out shinymeta! This package is currently       *\n",
-    "* _experimental_ and the API is still evolving. Please use         *\n",
-    "* caution, especially when upgrading to a newer shinymeta          *\n",
-    "* build. https://github.com/rstudio/shinymeta/blob/master/NEWS.md  *\n",
-    "********************************************************************"
-  )
-
   registerMethods(list(
     # c(package, genname, class)
     c("knitr", "knit_print", "shinyMetaExpr")

--- a/tests/testthat/_snaps/report/template.Rmd
+++ b/tests/testthat/_snaps/report/template.Rmd
@@ -12,3 +12,5 @@ plot(cars)
 ```
 
 The result is `r 1 + 1`.
+
+The values are 1 and 2.

--- a/tests/testthat/_snaps/report/template.Rmd
+++ b/tests/testthat/_snaps/report/template.Rmd
@@ -1,0 +1,14 @@
+---
+title: "A test template"
+output: html_document
+---
+
+# Weekly report
+
+Looks like `cars` hasn't changed since last week.
+
+```{r}
+plot(cars)
+```
+
+The result is `r 1 + 1`.

--- a/tests/testthat/assets/template.Rmd
+++ b/tests/testthat/assets/template.Rmd
@@ -1,0 +1,12 @@
+---
+title: "A test template"
+output: html_document
+---
+
+{{desc}}
+
+```{r}
+{{code_chunk}}
+```
+
+The result is `r {{code_inline}}`.

--- a/tests/testthat/assets/template.Rmd
+++ b/tests/testthat/assets/template.Rmd
@@ -10,3 +10,5 @@ output: html_document
 ```
 
 The result is `r {{code_inline}}`.
+
+The values are {{x}} and {{y}}.

--- a/tests/testthat/test-expansion.R
+++ b/tests/testthat/test-expansion.R
@@ -50,7 +50,7 @@ expect_equal_call <- function(actual, expected) {
   expect_equal(actual, expected)
 }
 
-test_that("mixed mode", isolate({
+test_that("mixed mode", {isolate({
   # A bunch of different kinds of metaReactive objects that should all
   # yield quote(1+1) in meta mode.
   srcs <- list(
@@ -103,4 +103,4 @@ test_that("mixed mode", isolate({
     mr5 <- metaRender(renderText, ..(src()))
     expect_equal_call(withMetaMode(mr5()), quote(1 + 1))
   })
-}))
+})})

--- a/tests/testthat/test-report.R
+++ b/tests/testthat/test-report.R
@@ -1,0 +1,32 @@
+template_path <- test_path("assets/template.Rmd")
+
+test_that("buildRmdBundle works", {
+  output_zip_path <- tempfile("testbundle-", fileext = ".zip")
+
+  buildRmdBundle(template_path, output_zip_path, vars = list(
+    desc = "# Weekly report\n\nLooks like `cars` hasn't changed since last week.",
+    code_chunk = metaExpr(quote({plot(cars)})),
+    code_inline = metaExpr(quote(1 + 1))
+  ))
+
+  working_dir <- tempfile()
+  dir.create(working_dir)
+  on.exit(unlink(working_dir, recursive = TRUE))
+
+  unzip(output_zip_path, exdir = working_dir)
+  expect_true(file.exists(file.path(working_dir, "template.html")))
+
+  expect_snapshot_file(file.path(working_dir, "template.Rmd"))
+})
+
+test_that("buildRmdBundle rejects unsafe knit_expand results", {
+  output_zip_path <- tempfile("testbundle-", fileext = ".zip")
+
+  expect_error(
+    buildRmdBundle(template_path, output_zip_path, vars = list(
+      desc = "# Weekly report\n\nLooks like `cars` hasn't changed since last week.\n```{r}\nmessage('owned')\n```\n",
+      code_chunk = metaExpr(quote({plot(cars)})),
+      code_inline = metaExpr(quote(1 + 1))
+    ))
+  )
+})

--- a/tests/testthat/test-report.R
+++ b/tests/testthat/test-report.R
@@ -6,7 +6,8 @@ test_that("buildRmdBundle works", {
   buildRmdBundle(template_path, output_zip_path, vars = list(
     desc = "# Weekly report\n\nLooks like `cars` hasn't changed since last week.",
     code_chunk = metaExpr(quote({plot(cars)})),
-    code_inline = metaExpr(quote(1 + 1))
+    code_inline = metaExpr(quote(1 + 1)),
+    x = 1, y = 2
   ))
 
   working_dir <- tempfile()
@@ -22,11 +23,43 @@ test_that("buildRmdBundle works", {
 test_that("buildRmdBundle rejects unsafe knit_expand results", {
   output_zip_path <- tempfile("testbundle-", fileext = ".zip")
 
+  # (Begin code chunk) fails
   expect_error(
     buildRmdBundle(template_path, output_zip_path, vars = list(
       desc = "# Weekly report\n\nLooks like `cars` hasn't changed since last week.\n```{r}\nmessage('owned')\n```\n",
       code_chunk = metaExpr(quote({plot(cars)})),
-      code_inline = metaExpr(quote(1 + 1))
+      code_inline = metaExpr(quote(1 + 1)),
+      x = 1, y = 2
+    ))
+  )
+
+  # (End code chunk) fails
+  expect_error(
+    buildRmdBundle(template_path, output_zip_path, vars = list(
+      desc = "# Weekly report\n\nLooks like `cars` hasn't changed since last week.\n```\n",
+      code_chunk = metaExpr(quote({plot(cars)})),
+      code_inline = metaExpr(quote(1 + 1)),
+      x = 1, y = 2
+    ))
+  )
+
+  # (Inline code) fails
+  expect_error(
+    buildRmdBundle(template_path, output_zip_path, vars = list(
+      desc = "# Weekly report\n\nLooks like `cars` hasn't changed since last week.\n`r message('owned')`\n",
+      code_chunk = metaExpr(quote({plot(cars)})),
+      code_inline = metaExpr(quote(1 + 1)),
+      x = 1, y = 2
+    ))
+  )
+
+  # Begin/end of inline.code are in two different spots - fails
+  expect_error(
+    buildRmdBundle(template_path, output_zip_path, vars = list(
+      desc = "# Weekly report\n\nLooks like `cars` hasn't changed since last week.\n",
+      code_chunk = metaExpr(quote({plot(cars)})),
+      code_inline = metaExpr(quote(1 + 1)),
+      x = "`r message('owned') #", y = "`"
     ))
   )
 })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -6,7 +6,7 @@ test_that("knit_expand_safe ignores calling environment", {
     "foo"
   )
   expect_identical(
-    knit_expand_safe(text = "{{ foo }}", foo = foo),
+    knit_expand_safe(text = "{{ foo }}", vars = list(foo = foo)),
     "bar"
   )
 
@@ -20,12 +20,18 @@ test_that("knit_expand_safe ignores calling environment", {
   )
 
   expect_identical(
-    local({ x <- "whatever"; knit_expand_safe(text = "{{ x }}", x = x) }),
+    local({ x <- "whatever"; knit_expand_safe(text = "{{ x }}", vars = list(x = x)) }),
     "whatever"
   )
 
   expect_identical(
     knit_expand_safe(text = "{{ toupper('hello') }}"),
     "HELLO"
+  )
+
+  # Use one of knit_expand_safe's parameter names as a var
+  expect_identical(
+    knit_expand_safe(text = "{{ text }}", vars = list(text = "something")),
+    "something"
   )
 })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,0 +1,31 @@
+test_that("knit_expand_safe ignores calling environment", {
+
+  foo <- "bar"
+  expect_error(
+    knit_expand_safe(text = "{{ foo }}"),
+    "foo"
+  )
+  expect_identical(
+    knit_expand_safe(text = "{{ foo }}", foo = foo),
+    "bar"
+  )
+
+  # matches_before is (at the time of this writing) a local variable in the
+  # knit_expand_safe, which is the parent.frame of knit_expand call. By default,
+  # knit_expand would be able to "see" that variable; knit_expand_safe is
+  # supposed to prevent that.
+  expect_error(
+    knit_expand_safe(text = "{{ matches_before }}"),
+    "matches_before"
+  )
+
+  expect_identical(
+    local({ x <- "whatever"; knit_expand_safe(text = "{{ x }}", x = x) }),
+    "whatever"
+  )
+
+  expect_identical(
+    knit_expand_safe(text = "{{ toupper('hello') }}"),
+    "HELLO"
+  )
+})


### PR DESCRIPTION
- [x] Either ensure that .rmd is the only template format we support, or, properly support `knit_expand_safe` for any format we do support.
- [x] `knit_expand_safe` should not read from the parent frame
- [x] Show notification to user when `buildRmdScript` fails in a `downloadHandler`
- [x] Fix tests (styler color codes)