### PR TITLE
adjust anchor name to fix internal link to section

### DIFF
--- a/vignettes/code-distribution.Rmd
+++ b/vignettes/code-distribution.Rmd
@@ -163,7 +163,7 @@ knitr::include_graphics("https://i.imgur.com/IV0gfZJ.gif")
 ```
 
 
-## Showing code {#showicode}
+## Showing code {#show-code}
 
 ### For an output 
 


### PR DESCRIPTION
The link from "showing code" in the initial paragraph is not working. This should fix it.