### PR TITLE
chore(license): Migrate license to MIT

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -11,3 +11,4 @@ examples
 ^Meta$
 ^\.github$
 ^vignettes$
+^LICENSE\.md$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,7 @@ Authors@R: c(
     )
 Description: Provides tools for capturing logic in a Shiny app and exposing it as code that can be run outside of Shiny (e.g., from an R console). It also provides tools for bundling both the code and results to the end user.
 URL: https://rstudio.github.io/shinymeta/, https://github.com/rstudio/shinymeta
-License: GPL-3
+License: MIT + file LICENSE
 Imports: 
   callr,
   fastmap,

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,2 @@
+YEAR: 2025
+COPYRIGHT HOLDER: shinymeta authors

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+# MIT License
+
+Copyright (c) 2025 shinymeta authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # 0.2.1.9000
 
-
+* Migrate GPL-3 license to MIT ()
 
 # 0.2.1
 


### PR DESCRIPTION
This pull request updates the licensing for the `shinymeta` package by migrating from GPL-3 to the MIT license. Key changes include updating metadata, adding a new license file, and documenting the change in the package's news file.
