### PR TITLE
Simplify unquoted symbols in metaExpr

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # shinymeta (development version)
 
+* Improved generated-code readability for Shiny apps using tidyeval. When `..()` is applied to a symbolic name (e.g., from `varSelectInput()`) and immediately unquoted with `!!`, the generated code now emits the bare symbol instead of `!!as.symbol("foo")`. The same applies to inline `!!sym(..(string))`, `!!as.name(..(string))`, and `!!rlang::sym(..(string))` patterns. (#125)
+
 # shinymeta 0.2.2
 
 * Fixed `mrexprSrcrefToLabel()` crash when Shiny's `sourceUTF8()` wraps app code with a `#line` directive. (#130)

--- a/R/metareactive.R
+++ b/R/metareactive.R
@@ -459,6 +459,7 @@ metaExpr <- function(expr, env = parent.frame(), quoted = FALSE, localize = "aut
   withMetaMode(mode = TRUE, {
     expr <- comment_flags(expr)
     expr <- expandExpr(expr, env)
+    expr <- simplify_unquoted_symbols(expr)
     expr <- strip_outer_brace(expr)
 
     # Note that bindToReturn won't make sense for a localized call,

--- a/R/utils-format.R
+++ b/R/utils-format.R
@@ -107,6 +107,23 @@ comment_flags_to_enclosings <- function(expr) {
   })
 }
 
+# Simplify `!!as.symbol("foo")` to `foo` in tidyeval contexts
+simplify_unquoted_symbols <- function(expr) {
+  walk_ast(expr, function(x) {
+    if (!rlang::is_call(x, "!", n = 1)) return(x)
+    if (!rlang::is_call(x[[2]], "!", n = 1)) return(x)
+
+    inner <- x[[2]][[2]]
+    if (!is_sym_constructor(inner)) return(x)
+
+    arg <- inner[[2]]
+    if (!is.character(arg) || length(arg) != 1 || is.na(arg) || !nzchar(arg)) {
+      return(x)
+    }
+    as.symbol(arg)
+  })
+}
+
 
 # ---------------------------------------------------------
 # Helpers
@@ -135,6 +152,25 @@ is_comment <- function(x) {
 
 is_illegal <- function(x) {
   identical(attr(x, "shinymeta_comment"), "illegal")
+}
+
+# Recognize `as.symbol(x)`, `as.name(x)`, `rlang::sym(x)`, `base::as.symbol(x)`,
+# etc. — any single-arg call to a known string-to-symbol constructor.
+is_sym_constructor <- function(x) {
+  if (!is.call(x) || length(x) != 2L) return(FALSE)
+  fn <- x[[1]]
+  if (is.symbol(fn)) {
+    return(as.character(fn) %in% c("as.symbol", "as.name", "sym"))
+  }
+  if (rlang::is_call(fn, "::", n = 2)) {
+    pkg <- as.character(fn[[2]])
+    nm  <- as.character(fn[[3]])
+    return(
+      (pkg == "base"  && nm %in% c("as.symbol", "as.name")) ||
+        (pkg == "rlang" && nm == "sym")
+    )
+  }
+  FALSE
 }
 
 

--- a/R/utils-format.R
+++ b/R/utils-format.R
@@ -107,9 +107,13 @@ comment_flags_to_enclosings <- function(expr) {
   })
 }
 
-# Simplify `!!as.symbol("foo")` to `foo` in tidyeval contexts
+# Simplify `!!as.symbol("foo")` to `foo` in tidyeval contexts and strip the
+# redundant parens left around a bare symbol
 simplify_unquoted_symbols <- function(expr) {
   walk_ast(expr, function(x) {
+    # drop redundant parens left wrapping a bare symbol
+    if (rlang::is_call(x, "(", n = 1) && is.symbol(x[[2]])) return(x[[2]])
+
     if (!rlang::is_call(x, "!", n = 1)) return(x)
     if (!rlang::is_call(x[[2]], "!", n = 1)) return(x)
 

--- a/tests/testthat/test-metareactive.R
+++ b/tests/testthat/test-metareactive.R
@@ -144,3 +144,66 @@ describe("metaAction", {
     expect_identical(i, 4)
   })
 })
+
+describe("!!as.symbol() simplification", isolate({
+  it("simplifies !!as.symbol('foo') to foo in generated code", {
+    input <- list(var = as.name("mpg"))
+    mr <- metaReactive({
+      mtcars %>%
+        dplyr::group_by(cyl) %>%
+        dplyr::summarise(mean_mpg = mean(!!..(input$var)))
+    })
+    code <- paste(formatCode(withMetaMode(mr())), collapse = "\n")
+    expect_match(code, "mean\\(mpg\\)")
+    expect_false(grepl("as.symbol", code, fixed = TRUE))
+  })
+
+  it("simplifies !!sym('foo') to foo", {
+    input <- list(var = "mpg")
+    mr <- metaReactive({
+      mtcars %>% dplyr::summarise(avg = mean(!!sym(..(input$var))))
+    })
+    code <- paste(formatCode(withMetaMode(mr())), collapse = "\n")
+    expect_match(code, "mean\\(mpg\\)")
+    expect_false(grepl("sym\\(", code))
+  })
+
+  it("simplifies !!rlang::sym('foo') to foo", {
+    input <- list(var = "mpg")
+    mr <- metaReactive({
+      mtcars %>% dplyr::summarise(avg = mean(!!rlang::sym(..(input$var))))
+    })
+    code <- paste(formatCode(withMetaMode(mr())), collapse = "\n")
+    expect_match(code, "mean\\(mpg\\)")
+  })
+
+  it("simplifies !!as.name('foo') to foo", {
+    input <- list(var = "mpg")
+    mr <- metaReactive({
+      mtcars %>% dplyr::summarise(avg = mean(!!as.name(..(input$var))))
+    })
+    code <- paste(formatCode(withMetaMode(mr())), collapse = "\n")
+    expect_match(code, "mean\\(mpg\\)")
+  })
+
+  it("leaves as.symbol() alone when not wrapped in !!", {
+    input <- list(var = as.name("mpg"))
+    mr <- metaReactive({
+      v <- ..(input$var)
+      print(v)
+    })
+    code <- paste(formatCode(withMetaMode(mr())), collapse = "\n")
+    # bare ..(symbol) outside !! should still be defensive
+    expect_match(code, "as.symbol", fixed = TRUE)
+  })
+
+  it("leaves as.symbol() alone when not in a tidyeval context", {
+    input <- TRUE
+    mr <- metaReactive({
+      !!input
+    })
+    code <- paste(formatCode(withMetaMode(mr())), collapse = "\n")
+    # bare ..(symbol) outside !! should still be defensive
+    expect_match(code, "!!input", fixed = TRUE)
+  })
+}))

--- a/vignettes/special-topics.Rmd
+++ b/vignettes/special-topics.Rmd
@@ -95,7 +95,7 @@ Modifying an existing Shiny app that uses modules may be more involved than simp
 
 ## Shiny, tidyeval, and shinymeta
 
-> TL;DR: The same steps in the [overview](#overview) will work for a Shiny app that uses [tidyeval](https://tidyeval.tidyverse.org/), but it probably won't produce the most readable code. To workaround that, if possible, try to avoid unquoting (i.e., `!!`/`!!!`) by using a functional interface that accepts character strings (instead of symbolic names).
+> TL;DR: The same steps in the [overview](#overview) will work for a Shiny app that uses [tidyeval](https://tidyeval.tidyverse.org/). When the reactive read is unquoted directly with `!!`, the generated code is the same as what you'd write by hand. When the conversion is bound to an intermediate variable, or when you're splicing multiple values with `!!!`, the generated code is functionally correct but reads slightly differently from hand-written code. Switching to `varSelectInput()` or to a function variant that takes character strings (e.g. `across(all_of(...))`) is the simplest fix where possible.
 
 Most **tidyverse** functions evaluate code expressions in a special context (e.g., they search for names within a data frame). That's how **dplyr** knows, for example, to lookup names (e.g. `cyl`) and evaluate calls (e.g., `mean(mpg)`) within a context defined by `mtcars`:
 
@@ -132,7 +132,7 @@ mtcars %>%
   summarise(avg = mean(!!var))
 ```
 
-Often times in a Shiny app we wish to pass an input value to a **tidyverse** function argument (as a variable). In most cases, that requires converting a string into a symbolic name, which can be done via `as.symbol()` or `rlang::sym()`. For example, here's a Shiny app to compute the mean of different `mtcars` variables by cylinder (`cyl`).
+Often times in a Shiny app we wish to pass an input value to a **tidyverse** function argument (as a variable). When the input is a character string, that requires converting it into a symbolic name with `as.symbol()` or `rlang::sym()` and then unquoting the result with `!!`. For example, here's a Shiny app to compute the mean of different `mtcars` variables by cylinder (`cyl`).
 
 ```{r, eval = FALSE}
 library(shiny)
@@ -143,10 +143,9 @@ ui <- fluidPage(
 )
 server <- function(input, output) {
   output$out <- renderPrint({
-    var_sym <- sym(input$var)
     mtcars %>%
       group_by(cyl) %>%
-      summarise(mean_mpg = mean(!!var_sym))
+      summarise(mean_mpg = mean(!!sym(input$var)))
   })
 }
 shinyApp(ui, server)
@@ -157,30 +156,12 @@ Adding **shinymeta** support in this case is straight-forward. As with any other
 ```{r, eval = FALSE}
 server <- function(input, output) {
   output$out <- metaRender(renderPrint, {
-    var_sym <- sym(..(input$var))
     mtcars %>%
       group_by(cyl) %>%
-      summarise(mean_mpg = mean(!!var_sym))
+      summarise(mean_mpg = mean(!!sym(..(input$var))))
   })
   observe(print(expandChain(output$out())))
 }
-```
-
-This pattern also works when you need to convert a character vector of strings into a list of symbolic names (splice them into a function call using `!!!`).
-
-```{r, eval = FALSE}
-ui <- fluidPage(
-  selectInput("var", "Select variables", names(mtcars), multiple = TRUE),
-  verbatimTextOutput("out")
-)
-server <- function(input, output) {
-  output$out <- metaRender(renderPrint, {
-    var_sym <- syms(..(input$var))
-    select(mtcars, !!!var_sym)
-  })
-  observe(print(expandChain(output$out())))
-}
-shinyApp(ui, server)
 ```
 
 In version v1.2.0, **shiny** introduced `varSelectInput()` essentially to remove the need to convert character string(s) into symbolic name(s). For example, in the app below, `input$var` already represents the symbolic name of interest, so you can do:
@@ -200,7 +181,7 @@ server <- function(input, output) {
 shinyApp(ui, server)
 ```
 
-As in the other examples, you can mark the reactive read with `..()` (before unquoting with `!!`) and the code generation should "just work". Technically speaking, this works because, when `..()` encounters a symbolic name that it doesn't recognize, it returns the code *to generate* the symbol instead of the bare symbol (i.e., it returns `as.symbol("mpg")` instead of `mpg` which makes the `!!` work in both normal and meta execution).
+As in the other examples, you can mark the reactive read with `..()` (before unquoting with `!!`) and the code generation should "just work". Technically speaking, this works because, when `..()` encounters a symbolic name that it doesn't recognize, it returns the code *to generate* the symbol instead of the bare symbol (i.e., it returns `as.symbol("mpg")` instead of `mpg` which makes the `!!` work in both normal and meta execution). When deparsed, `metaExpr()` recognizes the `!!as.symbol("foo")` pattern and collapses it back to the bare symbol `foo`, so the generated code matches what you'd write by hand.
 
 ```{r, eval = FALSE}
 server <- function(input, output) {
@@ -214,42 +195,46 @@ server <- function(input, output) {
 shinyApp(ui, server)
 ```
 
-In all the cases we've encountered thus far, the generated code is a bit different from how a human would write it. This last example produces code that looks like this:
+The examples above generate code identical to what a human would write. Two patterns still produce code that differs slightly from hand-written form.
+
+The first is the intermediate-variable form of the `sym()` conversion — binding the result of `sym(..(input$var))` to a name and then unquoting that name with `!!`:
 
 ```{r, eval = FALSE}
-mtcars %>%
-  group_by(cyl) %>%
-  summarise(mean_mpg = mean(!!as.symbol("mpg")))
+server <- function(input, output) {
+  output$out <- metaRender(renderPrint, {
+    var_sym <- sym(..(input$var))
+    mtcars %>%
+      group_by(cyl) %>%
+      summarise(mean_mpg = mean(!!var_sym))
+  })
+}
+shinyApp(ui, server)
 ```
 
-But what you'd probably want your app to generate is this:
+The generated code preserves both the `var_sym` assignment and the `!!var_sym` reference. The fix is the inline form `mean(!!sym(..(input$var)))` shown earlier in this section.
 
-```{r, eval = FALSE}
-mtcars %>%
-  group_by(cyl) %>%
-  summarise(mean_mpg = mean(mpg))
-```
-
-At least currently, there is no great workaround for this problem other than to use alternative **tidyverse** functions that allow you to avoid unquoting by using character strings instead of symbolic names. Most **dplyr** functions provide this alternative through `_at()` variants. These variants allow you to write code like:
-
-```{r, eval = FALSE}
-mtcars %>%
-  group_by(cyl) %>%
-  summarise_at("mpg", mean)
-```
-
-In this case, the implementation of the app is a lot simpler because we don't have to worry about unquoting; plus, the code that the app generates looks a lot more like code a human would write:
+The second is multi-value splicing with `!!!`:
 
 ```{r, eval = FALSE}
 ui <- fluidPage(
-  selectInput("var", "Select a variable", names(mtcars)),
+  selectInput("var", "Select variables", names(mtcars), multiple = TRUE),
   verbatimTextOutput("out")
 )
 server <- function(input, output) {
   output$out <- metaRender(renderPrint, {
-    mtcars %>%
-      group_by(cyl) %>%
-      summarise_at(..(input$var), mean)
+    select(mtcars, !!!syms(..(input$var)))
+  })
+  observe(print(expandChain(output$out())))
+}
+shinyApp(ui, server)
+```
+
+When `input$var` comes from `selectInput(multiple = TRUE)`, the generated code preserves the `!!!syms(...)` call rather than expanding it inline. The code is correct and runs as expected, but `!!!syms(c("mpg", "cyl"))` isn't what you'd write by hand. The simplest workaround is to use a function that takes character strings directly. For column selection specifically, the tidyselect helper `all_of()` works directly inside `select()`:
+
+```{r, eval = FALSE}
+server <- function(input, output) {
+  output$out <- metaRender(renderPrint, {
+    select(mtcars, all_of(..(input$var)))
   })
   observe(print(expandChain(output$out())))
 }


### PR DESCRIPTION
This strips `!!as.symbol` (and similar unquote symbol expressions) when using `metaExpr()` in tidyeval settings. As part of the fix, I've included additional tests and updated the tidyeval section of the special topics vignette.

Claude Chat assisted with identifying the root cause of the issue and drafted the code solution.

Fixes #125