### PR TITLE
Document usage of multiple `expandChain`s within `reactive()`

### DIFF
--- a/R/metareactive.R
+++ b/R/metareactive.R
@@ -660,6 +660,35 @@ print.shinymetaExpansionContext <- function(x, ...) {
 #' After this code is run, `chunk1` contains only the definition of `nums` and
 #' `chunk2` contains only the code for `obs`.
 #'
+#' Note that the expansion context is stateful: each `expandChain()` call
+#' records which `metaReactive` objects have already been emitted, and
+#' subsequent calls using the same context will suppress those definitions.
+#' This assumes the full sequence of `expandChain()` calls happens as a single
+#' batch.
+#'
+#' In a Shiny app, where individual outputs invalidate and re-render
+#' independently, this means a shared expansion context should be created
+#' inside a reactive expression that produces all the related chunks together,
+#' rather than at the top level of `server()`. If the context is created at
+#' the top level and consumed by multiple outputs, a partial invalidation can
+#' leave one of the chunks empty: the context remembers the definitions
+#' emitted on the previous render, and the re-rendering output skips them.
+#'
+#' ```
+#'     chunks <- reactive({
+#'       ec <- newExpansionContext()
+#'       list(
+#'         setup = expandChain(.expansionContext = ec, quote(library(ggplot2))),
+#'         data  = expandChain(.expansionContext = ec, filtered()),
+#'         plot  = expandChain(.expansionContext = ec, output$plot())
+#'       )
+#'     })
+#'
+#'     output$code_setup <- renderPrint(chunks()$setup)
+#'     output$code_data  <- renderPrint(chunks()$data)
+#'     output$code_plot  <- renderPrint(chunks()$plot)
+#' ```
+#'
 #' @section Substituting `metaReactive` objects:
 #'
 #' Sometimes, when generating code, we want to completely replace the

--- a/man/expandChain.Rd
+++ b/man/expandChain.Rd
@@ -131,6 +131,34 @@ the two calls.
 
 After this code is run, \code{chunk1} contains only the definition of \code{nums} and
 \code{chunk2} contains only the code for \code{obs}.
+
+Note that the expansion context is stateful: each \code{expandChain()} call
+records which \code{metaReactive} objects have already been emitted, and
+subsequent calls using the same context will suppress those definitions.
+This assumes the full sequence of \code{expandChain()} calls happens as a single
+batch.
+
+In a Shiny app, where individual outputs invalidate and re-render
+independently, this means a shared expansion context should be created
+inside a reactive expression that produces all the related chunks together,
+rather than at the top level of \code{server()}. If the context is created at
+the top level and consumed by multiple outputs, a partial invalidation can
+leave one of the chunks empty: the context remembers the definitions
+emitted on the previous render, and the re-rendering output skips them.
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{    chunks <- reactive(\{
+      ec <- newExpansionContext()
+      list(
+        setup = expandChain(.expansionContext = ec, quote(library(ggplot2))),
+        data  = expandChain(.expansionContext = ec, filtered()),
+        plot  = expandChain(.expansionContext = ec, output$plot())
+      )
+    \})
+
+    output$code_setup <- renderPrint(chunks()$setup)
+    output$code_data  <- renderPrint(chunks()$data)
+    output$code_plot  <- renderPrint(chunks()$plot)
+}\if{html}{\out{</div>}}
 }
 
 \section{Substituting \code{metaReactive} objects}{

--- a/vignettes/code-generation.Rmd
+++ b/vignettes/code-generation.Rmd
@@ -233,6 +233,23 @@ expandChain(output$plot(), .expansionContext = ec)
 expandChain(output$summary(), .expansionContext = ec)
 ```
 
+The expansion context is stateful — each `expandChain()` call records the `metaReactive` objects it has emitted, and subsequent calls using the same context will suppress those definitions. The synchronous, top-level usage above works fine because the two calls happen as one batch. In a Shiny app, where individual outputs invalidate and re-render independently, you should create the expansion context inside a single reactive that produces all the related chunks together, and then have each output read its chunk from that reactive:
+
+```{r, eval = FALSE}
+chunks <- reactive({
+  ec <- newExpansionContext()
+  list(
+    plot    = expandChain(output$plot(),    .expansionContext = ec),
+    summary = expandChain(output$summary(), .expansionContext = ec)
+  )
+})
+
+output$code_plot    <- renderPrint(chunks()$plot)
+output$code_summary <- renderPrint(chunks()$summary)
+```
+
+If instead you create the expansion context at the top of `server()` and use it from multiple `renderPrint()` outputs directly, a chunk can render empty after an input change: the context still remembers definitions emitted on a previous render, so when one of the consuming outputs re-runs in isolation, it suppresses the definitions that would otherwise have appeared in its chunk.
+
 Expansion contexts are also useful for cases where you need to redefine a meta-reactive's logic. This is useful in at least two scenarios:
 
 1. For efficiency or privacy reasons, you may not want to provide the "rawest" form of the data in your app to users. Instead, you might want to only provide a transformed and/or summarized version of the data. For example, instead of providing the user with `downloads`, we could provide `downloads_rolling` as file to be [included as part of a download bundle](code-distribution.html#including-other-files).


### PR DESCRIPTION
This adds a recommendation to the code docs and vignette that multiple `expandChain` calls with the same expansion context should be run within a single `reactive()` expression to ensure all `expandChain`s are run jointly.

Fixes #126